### PR TITLE
implement connection pooling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,16 +7,20 @@
   - pluggable/custom transport hooks
   - optional per-request `User-Agent` injection
   - optional uTLS transport with Chrome ClientHello emulation
+  - HTTP/2 connection pooling for uTLS transport (reuses connections across requests)
 
 ## Current Repository Structure
-- `chttp.go`: public API for client construction and helper utilities.
+- `chttp.go`: public API for client construction, `Close()`, and helper utilities.
 - `Makefile`: convenience targets for regular and integration test runs.
 - `transport/transport.go`: transport wrapper implementing pre/post request hooks.
-- `transport/utls.go`: uTLS-backed transport with default Chrome hello and optional custom ClientHello signature.
-- `chttp_test.go`: table-driven tests for `WithUserAgent`, cookie jar/domain handling, and helper utilities.
+- `transport/utls.go`: uTLS-backed transport with default Chrome hello, optional custom ClientHello signature, HTTP/2 connection pooling, and `Close()` for resource cleanup.
+- `transport/pool.go`: HTTP/2 connection pool (`connPool`) with identity-aware eviction, used internally by `UTLSTransport`.
+- `chttp_test.go`: table-driven tests for `WithUserAgent`, cookie jar/domain handling, `Close`, and helper utilities.
 - `transport/transport_test.go`: table-driven tests for `FuncTransport` callback behavior.
-- `transport/utls_test.go`: table-driven tests for uTLS transport and user-agent behavior.
+- `transport/utls_test.go`: table-driven tests for uTLS transport, user-agent behavior, and HTTP/2 connection reuse verification.
+- `transport/pool_test.go`: unit tests for `connPool` get/put, identity-aware removal, close, and concurrent access.
 - `transport/utls_integration_test.go`: opt-in external HTTPS connectivity integration tests, with optional debug HTML output (`TEST_DEBUG=1`).
+- `Pooling.md`: detailed design document for the HTTP/2 connection pooling implementation.
 - `README.md`: usage overview.
 
 ## Verified Current State
@@ -31,6 +35,8 @@
   - `WithClientHelloID(...)` for predefined signatures
   - `WithCustomClientHelloSpec(...)` for custom signatures
   - `WithUserAgent(...)` for transport-level UA injection
+  - `Close()` to release pooled HTTP/2 connections
+- `chttp.Close(cl)` is a package-level helper that calls `Close()` on the transport if it implements `io.Closer` (no-op for `FuncTransport`)
 
 ## Design Learnings
 - `NewWithTransport(cookieDomain, cookies, rt)`:
@@ -50,6 +56,9 @@
   - performs HTTPS handshake via `utls.UClient`
   - emulates Chrome hello by default (`utls.HelloChrome_Auto`)
   - supports HTTP/2 if ALPN negotiates `h2`, otherwise falls back to HTTP/1.1
+  - pools HTTP/2 `ClientConn` per host:port — subsequent requests reuse the connection
+  - identity-aware eviction prevents stale goroutines from removing newer connections
+  - `dialer` field is an interface (`dialer`) for testability; defaults to `*net.Dialer`
 
 ## Remaining Gaps / Risks
 - Core behavior is covered by table-driven tests and opt-in external integration tests, but proxy/TLS corner cases are still untested.
@@ -68,9 +77,11 @@
   1. cookie jar set/read and outbound cookie emission
   2. before/after transport callback execution
   3. invalid `cookieDomain` handling
-  4. helper behavior for `CookiesToPtr` and `Must`
+  4. helper behavior for `CookiesToPtr`, `Must`, and `Close`
   5. uTLS round-trip (default + custom hello spec)
   6. uTLS transport-level user-agent injection
+  7. HTTP/2 connection reuse (asserts single TCP dial across multiple requests)
+  8. connection pool get/put, identity-aware removal, close, and concurrent access
 
 ## Conventions Observed
 - Standard-library-first implementation with small API surface.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Features:
 - Cookie jar initialization and seeding for a target domain.
 - Option-based request customization (`WithUserAgent`).
 - Optional uTLS transport (`WithUTLS`) with Chrome ClientHello emulation by default.
+- HTTP/2 connection pooling for uTLS transport — connections are reused across requests.
 - Transport hooks via `transport.FuncTransport` (`BeforeReq` / `AfterReq`).
 
 Simple usage:
@@ -49,6 +50,7 @@ func getWithUTLS() error {
 	if err != nil {
 		return err
 	}
+	defer chttp.Close(cl) // releases pooled connections
 
 	resp, err := cl.Get("https://example.com")
 	if err != nil {

--- a/chttp.go
+++ b/chttp.go
@@ -7,6 +7,7 @@
 package chttp
 
 import (
+	"io"
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
@@ -98,6 +99,16 @@ func CookiesToPtr(cookies []http.Cookie) []*http.Cookie {
 		ret[i] = &cookies[i]
 	}
 	return ret
+}
+
+// Close releases resources held by the client's transport. It is safe to call
+// on clients whose transport does not require cleanup (e.g. FuncTransport) —
+// in that case it is a no-op.
+func Close(cl *http.Client) error {
+	if c, ok := cl.Transport.(io.Closer); ok {
+		return c.Close()
+	}
+	return nil
 }
 
 // Must is a helper function to panic on error.

--- a/chttp_test.go
+++ b/chttp_test.go
@@ -223,6 +223,33 @@ func TestCookiesToPtr(t *testing.T) {
 	}
 }
 
+func TestClose(t *testing.T) {
+	t.Run("utls transport", func(t *testing.T) {
+		cl, err := New("https://example.com", nil, WithUTLS(nil))
+		if err != nil {
+			t.Fatalf("New: %v", err)
+		}
+		if err := Close(cl); err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+	})
+	t.Run("func transport noop", func(t *testing.T) {
+		cl, err := New("https://example.com", nil)
+		if err != nil {
+			t.Fatalf("New: %v", err)
+		}
+		if err := Close(cl); err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+	})
+	t.Run("nil transport noop", func(t *testing.T) {
+		cl := &http.Client{}
+		if err := Close(cl); err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+	})
+}
+
 func TestMust(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/transport/pool.go
+++ b/transport/pool.go
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package transport
+
+import (
+	"sync"
+
+	"golang.org/x/net/http2"
+)
+
+// connPool manages pooled HTTP/2 client connections keyed by host:port.
+// A single http2.ClientConn can multiplex many concurrent requests.
+type connPool struct {
+	mu      sync.Mutex
+	h2Conns map[string]*http2.ClientConn
+	closed  bool
+}
+
+func newConnPool() *connPool {
+	return &connPool{
+		h2Conns: make(map[string]*http2.ClientConn),
+	}
+}
+
+// getH2 returns a cached HTTP/2 client connection for addr if one exists
+// and can still accept new requests. Stale entries are evicted.
+func (p *connPool) getH2(addr string) (*http2.ClientConn, bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.closed {
+		return nil, false
+	}
+
+	cc, ok := p.h2Conns[addr]
+	if !ok {
+		return nil, false
+	}
+	if !cc.CanTakeNewRequest() {
+		delete(p.h2Conns, addr)
+		return nil, false
+	}
+	return cc, true
+}
+
+// putH2 stores an HTTP/2 client connection for addr. If a usable connection
+// already exists (e.g. from a concurrent dial race), the existing one is kept
+// and the new one is returned so the caller can close it.
+func (p *connPool) putH2(addr string, cc *http2.ClientConn) (existing *http2.ClientConn, stored bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.closed {
+		return nil, false
+	}
+
+	if prev, ok := p.h2Conns[addr]; ok && prev.CanTakeNewRequest() {
+		// A usable connection already exists; caller should use it and
+		// close the new one.
+		return prev, false
+	}
+
+	p.h2Conns[addr] = cc
+	return nil, true
+}
+
+// removeH2 removes the cached connection for addr, but only if it is the
+// same connection as cc. This prevents a stale request from evicting a
+// newer healthy connection that another goroutine has already stored.
+func (p *connPool) removeH2(addr string, cc *http2.ClientConn) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.h2Conns[addr] == cc {
+		delete(p.h2Conns, addr)
+	}
+}
+
+// Close closes all pooled connections and marks the pool as closed.
+func (p *connPool) Close() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.closed = true
+	for addr, cc := range p.h2Conns {
+		cc.Close()
+		delete(p.h2Conns, addr)
+	}
+	return nil
+}

--- a/transport/pool_test.go
+++ b/transport/pool_test.go
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package transport
+
+import (
+	"crypto/tls"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"golang.org/x/net/http2"
+)
+
+// newTestH2Server returns a TLS server that speaks HTTP/2 and a function
+// that dials it and returns an h2 ClientConn.
+func newTestH2Server(t *testing.T) (srv *httptest.Server, dial func() *http2.ClientConn) {
+	t.Helper()
+	srv = httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	srv.EnableHTTP2 = true
+	srv.StartTLS()
+	t.Cleanup(srv.Close)
+
+	h2tr := &http2.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+
+	dial = func() *http2.ClientConn {
+		t.Helper()
+		conn, err := tls.Dial("tcp", srv.Listener.Addr().String(), &tls.Config{
+			InsecureSkipVerify: true,
+			NextProtos:         []string{"h2"},
+		})
+		if err != nil {
+			t.Fatalf("tls.Dial: %v", err)
+		}
+		t.Cleanup(func() { conn.Close() })
+		cc, err := h2tr.NewClientConn(conn)
+		if err != nil {
+			t.Fatalf("NewClientConn: %v", err)
+		}
+		return cc
+	}
+	return srv, dial
+}
+
+func TestConnPool_GetPut(t *testing.T) {
+	_, dial := newTestH2Server(t)
+	p := newConnPool()
+	addr := "example.com:443"
+
+	if _, ok := p.getH2(addr); ok {
+		t.Fatal("expected empty pool to return nothing")
+	}
+
+	cc := dial()
+	existing, stored := p.putH2(addr, cc)
+	if !stored || existing != nil {
+		t.Fatal("expected first put to store successfully")
+	}
+
+	got, ok := p.getH2(addr)
+	if !ok {
+		t.Fatal("expected to get cached connection")
+	}
+	if got != cc {
+		t.Fatal("expected same connection back")
+	}
+}
+
+func TestConnPool_PutRace(t *testing.T) {
+	_, dial := newTestH2Server(t)
+	p := newConnPool()
+	addr := "example.com:443"
+
+	cc1 := dial()
+	p.putH2(addr, cc1)
+
+	// A second put for the same addr should return the existing conn.
+	cc2 := dial()
+	existing, stored := p.putH2(addr, cc2)
+	if stored {
+		t.Fatal("expected second put to not store")
+	}
+	if existing != cc1 {
+		t.Fatal("expected existing connection to be returned")
+	}
+}
+
+func TestConnPool_RemoveIdentityAware(t *testing.T) {
+	_, dial := newTestH2Server(t)
+	p := newConnPool()
+	addr := "example.com:443"
+
+	cc1 := dial()
+	p.putH2(addr, cc1)
+
+	// Replace cc1 with cc2 (simulating a goroutine that dialed fresh).
+	cc2 := dial()
+	// Force-replace: remove cc1, then put cc2.
+	p.removeH2(addr, cc1)
+	p.putH2(addr, cc2)
+
+	// Now a stale goroutine tries to remove using the old cc1 identity.
+	// This must NOT evict cc2.
+	p.removeH2(addr, cc1)
+
+	got, ok := p.getH2(addr)
+	if !ok {
+		t.Fatal("removeH2 with stale identity should not have evicted the newer connection")
+	}
+	if got != cc2 {
+		t.Fatal("expected cc2 to remain in pool")
+	}
+}
+
+func TestConnPool_Close(t *testing.T) {
+	_, dial := newTestH2Server(t)
+	p := newConnPool()
+	addr := "example.com:443"
+
+	p.putH2(addr, dial())
+
+	if err := p.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	if _, ok := p.getH2(addr); ok {
+		t.Fatal("expected closed pool to return nothing")
+	}
+
+	_, stored := p.putH2(addr, dial())
+	if stored {
+		t.Fatal("expected put to closed pool to fail")
+	}
+}
+
+func TestConnPool_ConcurrentAccess(t *testing.T) {
+	_, dial := newTestH2Server(t)
+	p := newConnPool()
+
+	var wg sync.WaitGroup
+	for i := range 10 {
+		wg.Add(1)
+		addr := net.JoinHostPort("example.com", "443")
+		_ = i
+		go func() {
+			defer wg.Done()
+			cc := dial()
+			p.putH2(addr, cc)
+			p.getH2(addr)
+		}()
+	}
+	wg.Wait()
+
+	if err := p.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+}

--- a/transport/utls.go
+++ b/transport/utls.go
@@ -4,6 +4,7 @@ package transport
 
 import (
 	"bufio"
+	"context"
 	"crypto/tls"
 	"errors"
 	"fmt"
@@ -17,18 +18,24 @@ import (
 	"golang.org/x/net/http2"
 )
 
+// dialer is the interface used by UTLSTransport to establish TCP connections.
+type dialer interface {
+	DialContext(ctx context.Context, network, addr string) (net.Conn, error)
+}
+
 // UTLSTransport is an http.RoundTripper using uTLS for HTTPS handshakes.
 //
 // It emulates Chrome's ClientHello by default. A custom TLS signature can be
 // provided via CustomClientHelloSpec.
 type UTLSTransport struct {
-	dialer                *net.Dialer
+	dialer                dialer
 	tlsConfig             *utls.Config
 	clientHelloID         utls.ClientHelloID
 	customClientHelloSpec *utls.ClientHelloSpec
 	userAgent             string
 	h2                    *http2.Transport
 	http                  http.RoundTripper
+	pool                  *connPool
 }
 
 // NewUTLSTransport returns a new uTLS transport.
@@ -52,6 +59,7 @@ func NewUTLSTransport(tlsConfig *utls.Config) *UTLSTransport {
 			},
 		},
 		http: http.DefaultTransport,
+		pool: newConnPool(),
 	}
 }
 
@@ -94,12 +102,23 @@ func (t *UTLSTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		addr += ":443"
 	}
 
+	// Try reusing a pooled HTTP/2 connection.
+	if cc, ok := t.pool.getH2(addr); ok {
+		resp, err := cc.RoundTrip(r)
+		if err == nil {
+			return resp, nil
+		}
+		// Connection went bad; remove only if it's still the same entry
+		// (another goroutine may have already replaced it with a fresh one).
+		t.pool.removeH2(addr, cc)
+	}
+
 	conn, err := t.dialer.DialContext(req.Context(), "tcp", addr)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := t.roundTripTLS(r, conn)
+	resp, err := t.roundTripTLS(r, conn, addr)
 	if err != nil {
 		_ = conn.Close()
 		return nil, err
@@ -108,7 +127,12 @@ func (t *UTLSTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	return resp, nil
 }
 
-func (t *UTLSTransport) roundTripTLS(req *http.Request, rawConn net.Conn) (*http.Response, error) {
+// Close closes idle connections held by this transport.
+func (t *UTLSTransport) Close() error {
+	return t.pool.Close()
+}
+
+func (t *UTLSTransport) roundTripTLS(req *http.Request, rawConn net.Conn, addr string) (*http.Response, error) {
 	tlsCfg := t.tlsConfig.Clone()
 	if tlsCfg.ServerName == "" {
 		tlsCfg.ServerName = req.URL.Hostname()
@@ -134,6 +158,12 @@ func (t *UTLSTransport) roundTripTLS(req *http.Request, rawConn net.Conn) (*http
 		cc, err := t.h2.NewClientConn(uConn)
 		if err != nil {
 			return nil, err
+		}
+		// Pool the connection. If another goroutine raced and already
+		// stored one, use that instead and close our new connection.
+		if existing, stored := t.pool.putH2(addr, cc); !stored && existing != nil {
+			_ = uConn.Close()
+			return existing.RoundTrip(req)
 		}
 		return cc.RoundTrip(req)
 	}

--- a/transport/utls_test.go
+++ b/transport/utls_test.go
@@ -3,13 +3,28 @@
 package transport
 
 import (
+	"context"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	utls "github.com/refraction-networking/utls"
 )
+
+// dialCounter wraps a net.Dialer and counts the number of DialContext calls.
+type dialCounter struct {
+	inner *net.Dialer
+	count atomic.Int64
+}
+
+func (d *dialCounter) DialContext(ctx context.Context, network, addr string) (net.Conn, error) {
+	d.count.Add(1)
+	return d.inner.DialContext(ctx, network, addr)
+}
 
 func TestUTLSTransport_RoundTrip(t *testing.T) {
 	tests := []struct {
@@ -65,6 +80,56 @@ func TestUTLSTransport_RoundTrip(t *testing.T) {
 				t.Fatalf("unexpected body: %q", string(b))
 			}
 		})
+	}
+}
+
+func TestUTLSTransport_ConnectionReuse(t *testing.T) {
+	var (
+		mu            sync.Mutex
+		reqCount      int
+		protoVersions = make(map[string]int)
+	)
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		reqCount++
+		protoVersions[r.Proto]++
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	srv.EnableHTTP2 = true
+	srv.StartTLS()
+	defer srv.Close()
+
+	tr := NewUTLSTransport(&utls.Config{InsecureSkipVerify: true})
+	defer tr.Close()
+
+	// Wrap the dialer to count TCP connections (each represents a TLS handshake).
+	dc := &dialCounter{inner: tr.dialer.(*net.Dialer)}
+	tr.dialer = dc
+
+	cl := &http.Client{Transport: tr}
+
+	// Make multiple sequential requests to the same server.
+	for range 5 {
+		resp, err := cl.Get(srv.URL)
+		if err != nil {
+			t.Fatalf("request failed: %v", err)
+		}
+		io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if reqCount != 5 {
+		t.Fatalf("expected 5 requests, got %d", reqCount)
+	}
+	if protoVersions["HTTP/2.0"] != 5 {
+		t.Fatalf("expected all 5 requests over HTTP/2, got protocol distribution: %v", protoVersions)
+	}
+	if dials := dc.count.Load(); dials != 1 {
+		t.Fatalf("expected 1 TCP dial (connection reuse), got %d", dials)
 	}
 }
 


### PR DESCRIPTION
# HTTP/2 Connection Pooling for UTLSTransport

## Problem

`UTLSTransport.RoundTrip` opened a new TCP connection and performed a full uTLS
handshake on every HTTPS request. The standard `http.Transport` (used before
v2.0.0) pools connections and reuses them. This caused a ~15% wall-clock
regression in downstream consumers (e.g. slackdump archive: 21.8 s to > 25 s)
because each API call paid TCP + TLS setup overhead that should only happen once
per host.

## Solution

Add an HTTP/2 connection pool (`connPool`) to `UTLSTransport`. A single
`http2.ClientConn` can multiplex many concurrent requests over one TLS
connection, so caching one per host eliminates repeated handshakes for the
common case (most modern APIs negotiate HTTP/2).

HTTP/1.1 connections are **not** pooled; they keep the existing
close-after-use behaviour via `closeConnReadCloser`.

## Changed Files

| File | What changed |
|------|-------------|
| `transport/pool.go` | **New.** `connPool` struct with mutex-protected `map[string]*http2.ClientConn`. Methods: `getH2`, `putH2`, `removeH2`, `Close`. |
| `transport/utls.go` | Added `pool *connPool` field to `UTLSTransport`. `dialer` field changed from `*net.Dialer` to `dialer` interface (for testability). `RoundTrip` checks the pool before dialing; removal is identity-aware. `roundTripTLS` stores new h2 connections after handshake. New `Close()` method for cleanup. |
| `transport/pool_test.go` | **New.** Unit tests for pool get/put, put-race dedup, identity-aware removal, close, and concurrent access. |
| `transport/utls_test.go` | Added `dialCounter` test helper and `TestUTLSTransport_ConnectionReuse` — verifies 5 sequential requests over HTTP/2, asserts exactly 1 TCP dial (proving h2 connection reuse). |

## RoundTrip Flow (after change)

```
RoundTrip(req)
  1. Clone request, set User-Agent
  2. Non-HTTPS --> delegate to t.http (stdlib, already pooled)
  3. addr = host:port
  4. pool.getH2(addr) --> if usable cc exists, cc.RoundTrip(req)
     - on error: pool.removeH2(addr, cc), fall through (identity-aware)
  5. Dial TCP, uTLS handshake
  6. If h2 negotiated:
       cc = h2.NewClientConn(uConn)
       pool.putH2(addr, cc)  // race-safe: keeps existing if one appeared
       cc.RoundTrip(req)
  7. If h1: write/read on raw conn, close after body read (no pooling)
```

## connPool API

```go
getH2(addr string) (*http2.ClientConn, bool)
```
Returns a cached connection if `CanTakeNewRequest()` is true. Evicts stale
entries lazily.

```go
putH2(addr string, cc *http2.ClientConn) (existing *http2.ClientConn, stored bool)
```
Stores a connection. If a usable one already exists (concurrent dial race), returns
it instead so the caller can close the duplicate and use the existing one.

```go
removeH2(addr string, cc *http2.ClientConn)
```
Evicts a failed connection so the next request dials fresh. Identity-aware:
only removes the entry if it is the exact same `*http2.ClientConn` as `cc`.
This prevents a stale goroutine from evicting a newer healthy connection that
another goroutine has already stored for the same host.

```go
Close() error
```
Closes all pooled connections, marks pool as closed. Subsequent get/put are
no-ops.

## Concurrency

- All pool methods are protected by `sync.Mutex`.
- `http2.ClientConn` is safe for concurrent `RoundTrip` calls.
- Concurrent dial race: two goroutines may both miss the pool, both dial, both
  call `putH2`. The second caller gets the first's connection back and closes
  its own — at most one redundant dial, no data corruption.
- Identity-aware removal: a stale goroutine that fails on an old connection
  cannot evict a newer healthy connection stored by another goroutine.

## Caller Responsibilities

- Call `UTLSTransport.Close()` when the transport is no longer needed to release
  pooled connections.
- HTTP/1.1 connections are still one-shot. If the target server does not
  negotiate HTTP/2, there is no pooling benefit.

## Testing

```sh
go test ./...                     # unit + transport tests
go test -race ./...               # race detector
CHTTP_RUN_INTEGRATION_TESTS=1 \
  go test ./transport/ -run Integration  # external sites
```
